### PR TITLE
Auto update

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ npm run dist
 ```
 
 Packages will be stored in `release/`.
+
+### Signing OSX Packages
+Signed OSX packages are required for the Auto-Update functionality to work. In order to sign an a package you need to have an Apple developer certificate available. You can do this by opening XCode, Preferences -> Accounts -> Sign in with Apple ID enrolled in Developer Program -> View Details. When you have downloaded the 'Developer ID Application' certificate, you can look in Keychain Access -> Login -> Certificates to verify that the certificate has been installed. From this screen copy the full name of the certificate. You can now build a signed package with:
+```
+env CSC_NAME="<identity cert name>" npm run dist
+```
+More info on automatic signing (not just for OSX) [here](https://github.com/electron-userland/electron-builder/wiki/Code-Signing).
+
+You can verify the signature with `codesign --verify -vvvv release/osx/AppName.app`.

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -1,0 +1,95 @@
+const electron = require('electron');
+const autoUpdater = electron.autoUpdater;
+const currentVersion = require('../package.json').version;
+const os = require('os');
+const request = require('request');
+
+
+module.exports = function autoUpdate(browserWindow) {
+  const feedUrl = `http://localhost:8000/update/${os.platform()}_${os.arch()}/${currentVersion}`;
+
+  if (false && process.platform !== 'linux') {
+    console.log('checking for updates at', feedUrl);
+    autoUpdater.setFeedURL(feedUrl);
+
+    autoUpdater.addListener(
+      'update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateUrl) => {
+        console.log(releaseName, updateUrl);
+        electron.dialog.showMessageBox(browserWindow, {
+          type: 'info',
+          buttons: ['Install & Resart', 'Later'],
+          defaultId: 0, // Index of pre-selected button
+          title: 'Update Available',
+           // Should include change log or something
+          message: 'An update has been downloaded',
+          detail: 'We recommend you install it now.',
+          cancelId: 1, // Return the cancel id if the user closes dialog without clicking a button
+        }, (response) => {
+          console.log(response);
+          if (response === 0) {
+            autoUpdater.quitAndInstall();
+          } else {
+            console.log('canceled');
+          }
+        });
+      });
+
+    autoUpdater.addListener('error', (error) => {
+      console.log('encountered error', error.message);
+    });
+
+    autoUpdater.addListener('update-not-available', () => {
+      console.log('update not found');
+    });
+
+    autoUpdater.addListener('update-available', () => {
+      console.log('update found');
+    });
+
+    autoUpdater.addListener('checking-for-update', () => {
+      console.log('checking for update');
+    });
+
+    autoUpdater.checkForUpdates();
+  } else { // linux
+    const options = {
+      url: 'https://api.github.com/repos/atom/atom/releases/latest',
+      headers: {
+        'User-Agent': 'GabeIsman'
+      }
+    }
+    request(options, (error, response, body) => {
+      if (error) {
+        console.log(error);
+        // Fail silently
+        return;
+      }
+
+      try {
+        body = JSON.parse(body);
+      } catch (e) {
+        console.log(e);
+        return;
+      }
+
+      if (body.name.indexOf(currentVersion) !==) {
+        // Up to date
+        return;  
+      }
+
+      electron.dialog.showMessageBox(browserWindow, {
+        type: 'info',
+        buttons: ['Ok'],
+        defaultId: 0, // Index of pre-selected button
+        title: 'Update Available',
+         // Should include change log or something
+        message: 'An update is available',
+        detail: `We recommend you install it now through your package manager or by visiting ${body.html_url}.`,
+        cancelId: 0, // Return the cancel id if the user closes dialog without clicking a button
+      });
+    });
+    // try to GET /repos/:owner/:repo/releases/latest
+    // if successful compare to 'name' or 'tag_name' to current version
+    // if out of date link to 'html_url'
+  }
+};

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -1,6 +1,6 @@
 const electron = require('electron');
 const autoUpdater = electron.autoUpdater;
-const currentVersion = require('../package.json').version;
+const currentVersion = electron.app.getVersion();
 const os = require('os');
 const request = require('request');
 const repo = 'atom/atom' // TESTING ONLY, change to 'freedomofpress/sunder'
@@ -9,7 +9,7 @@ const repo = 'atom/atom' // TESTING ONLY, change to 'freedomofpress/sunder'
 module.exports = function autoUpdate(browserWindow) {
 
   if (process.platform !== 'linux') {
-    const feedUrl = `http://localhost:8000/update/${os.platform()}_${os.arch()}/${currentVersion}`;
+    const feedUrl = `http://localhost:5000/update/${os.platform()}_${os.arch()}/${currentVersion}`;
     console.log('checking for updates at', feedUrl);
     autoUpdater.setFeedURL(feedUrl);
 
@@ -51,7 +51,9 @@ module.exports = function autoUpdate(browserWindow) {
       console.log('checking for update');
     });
 
-    autoUpdater.checkForUpdates();
+    if (process.env.NODE_ENV === 'production') {
+      autoUpdater.checkForUpdates();
+    }
   } else { // linux
     const options = {
       url: `https://api.github.com/repos/${repo}/releases/latest`,

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -64,7 +64,7 @@ module.exports = function autoUpdate(browserWindow) {
         return;
       }
 
-      if (body.name.indexOf(currentVersion) !== -1) {
+      if (body.tag_name.indexOf(currentVersion) !== -1) {
         // Up to date
         return;
       }

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -3,12 +3,13 @@ const autoUpdater = electron.autoUpdater;
 const currentVersion = require('../package.json').version;
 const os = require('os');
 const request = require('request');
+const repo = 'atom/atom' // TESTING ONLY, change to 'freedomofpress/sunder'
 
 
 module.exports = function autoUpdate(browserWindow) {
-  const feedUrl = `http://localhost:8000/update/${os.platform()}_${os.arch()}/${currentVersion}`;
 
-  if (false && process.platform !== 'linux') {
+  if (process.platform !== 'linux') {
+    const feedUrl = `http://localhost:8000/update/${os.platform()}_${os.arch()}/${currentVersion}`;
     console.log('checking for updates at', feedUrl);
     autoUpdater.setFeedURL(feedUrl);
 
@@ -53,9 +54,9 @@ module.exports = function autoUpdate(browserWindow) {
     autoUpdater.checkForUpdates();
   } else { // linux
     const options = {
-      url: 'https://api.github.com/repos/atom/atom/releases/latest',
+      url: `https://api.github.com/repos/${repo}/releases/latest`,
       headers: {
-        'User-Agent': 'GabeIsman'
+        'User-Agent': 'Sunder'
       }
     }
     request(options, (error, response, body) => {
@@ -72,9 +73,9 @@ module.exports = function autoUpdate(browserWindow) {
         return;
       }
 
-      if (body.name.indexOf(currentVersion) !==) {
+      if (body.name.indexOf(currentVersion) !== -1) {
         // Up to date
-        return;  
+        return;
       }
 
       electron.dialog.showMessageBox(browserWindow, {
@@ -88,8 +89,5 @@ module.exports = function autoUpdate(browserWindow) {
         cancelId: 0, // Return the cancel id if the user closes dialog without clicking a button
       });
     });
-    // try to GET /repos/:owner/:repo/releases/latest
-    // if successful compare to 'name' or 'tag_name' to current version
-    // if out of date link to 'html_url'
   }
 };

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -3,6 +3,8 @@ const autoUpdater = electron.autoUpdater;
 const currentVersion = electron.app.getVersion();
 const os = require('os');
 const request = require('request');
+const semver = require('semver');
+
 const repo = 'freeedomofpress/sunder' // TODO: verify this repo is accurate once public
 
 
@@ -64,21 +66,28 @@ module.exports = function autoUpdate(browserWindow) {
         return;
       }
 
-      if (body.tag_name.indexOf(currentVersion) !== -1) {
-        // Up to date
+      if (!semver.valid(body.tag_name)) {
+        console.error(`Invalid version for latest release returned by GitHub: ${body.tag_name}`);
         return;
       }
 
-      electron.dialog.showMessageBox(browserWindow, {
-        type: 'info',
-        buttons: ['Ok'],
-        defaultId: 0, // Index of pre-selected button
-        title: 'Update Available',
-         // Should include change log or something
-        message: 'An update is available',
-        detail: `We recommend you install it now through your package manager or by visiting ${body.html_url}.`,
-        cancelId: 0, // Return the cancel id if the user closes dialog without clicking a button
-      });
+      if (!semver.valid(currentVersion)) {
+        console.error(`Invalid current version: ${currentVersion}`);
+        return;
+      }
+
+      if (semver.gt(body.tag_name, currentVersion)) {
+        electron.dialog.showMessageBox(browserWindow, {
+          type: 'info',
+          buttons: ['Ok'],
+          defaultId: 0, // Index of pre-selected button
+          title: 'Update Available',
+           // Should include change log or something
+          message: 'An update is available',
+          detail: `We recommend you install it now through your package manager or by visiting ${body.html_url}.`,
+          cancelId: 0, // Return the cancel id if the user closes dialog without clicking a button
+        });
+      }
     });
   }
 };

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -21,11 +21,11 @@ module.exports = function autoUpdate(browserWindow) {
         'update-downloaded', (event, releaseNotes, releaseName, releaseDate, updateUrl) => {
           electron.dialog.showMessageBox(browserWindow, {
             type: 'info',
-            buttons: ['Install & Resart', 'Later'],
+            buttons: ['Install & Restart', 'Later'],
             defaultId: 0, // Index of pre-selected button
             title: 'Update Available',
             // Should include change log or something
-            message: 'An update has been downloaded',
+            message: 'An update is available',
             detail: 'We recommend you install it now.',
             cancelId: 1, // Return the cancel id if the user closes dialog without clicking a button
           }, (response) => {

--- a/app/autoUpdate.js
+++ b/app/autoUpdate.js
@@ -28,7 +28,7 @@ module.exports = function autoUpdate(browserWindow) {
         }, (response) => {
           console.log(response);
           if (response === 0) {
-            autoUpdater.quitAndInstall();
+            setTimeout(() => autoUpdater.quitAndInstall(), 1);
           } else {
             console.log('canceled');
           }

--- a/app/main.js
+++ b/app/main.js
@@ -4,6 +4,7 @@
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
 const electron = require('electron');
+const autoUpdate = require('./autoUpdate');
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
 let mainWindow = null;
@@ -30,4 +31,6 @@ app.on('ready', () => {
   if (process.env.NODE_ENV === 'development') {
     mainWindow.openDevTools();
   }
+
+  autoUpdate(mainWindow);
 });

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/freedomofpress/secretshare.git",
   "description": "Desktop application providing a simple UI for the Shamir secret sharing scheme.",
   "author": "Gabe Isman <gabe.isman@gmail.com>",
+  "license": "MIT",
   "dependencies": {
     "rusty-secrets": "0.0.6",
     "request": "^2.72.0"

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
   "description": "Desktop application providing a simple UI for the Shamir secret sharing scheme.",
   "author": "Gabe Isman <gabe.isman@gmail.com>",
   "dependencies": {
-    "rusty-secrets": "0.0.6"
+    "rusty-secrets": "0.0.6",
+    "request": "^2.72.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,8 +109,7 @@
     "redux": "^3.2.1",
     "redux-form": "^5.1.1",
     "redux-promise": "^0.5.0",
-    "redux-thunk": "^2.0.0",
-    "request": "^2.72.0"
+    "redux-thunk": "^2.0.0"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "redux": "^3.2.1",
     "redux-form": "^5.1.1",
     "redux-promise": "^0.5.0",
-    "redux-thunk": "^2.0.0"
+    "redux-thunk": "^2.0.0",
+    "request": "^2.72.0"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "bin": {
     "electron": "./node_modules/.bin/electron"
   },
-  "license": "MIT",
   "devDependencies": {
     "asar": "^0.11.0",
     "babel-core": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "asar": false,
     "linux": {
       "icon": "build/icons/",
-      "target": ["deb"]
+      "target": [
+        "deb"
+      ]
     }
   },
   "bin": {
@@ -96,7 +98,8 @@
     "redux": "^3.6.0",
     "redux-form": "^5.3.6",
     "redux-promise": "^0.5.1",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "semver": "^5.3.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
This adds auto update functionality.

### On OSX
It leverages the [Squirrel framework](https://github.com/Squirrel/Squirrel.Mac) via electron's built-in auto-update library for a pretty seamless experience. On startup it checks for updates by pinging a [nuts server](https://github.com/GitbookIO/nuts), which is uses github releases as the only backend. If an update is found it is downloaded in the background and the user is prompted to install it, which restarts the app. The user can decline to install the update.

### On Linux
It pings the public github releases API and compares the tag name of the latest release to the version that is currently running. If the current version string is not a substring of the latest then the user is notified that there is an update that should be installed through their package manager, or by visiting the release page (which is included in the message, although not linked). This version comparison is a bit of a hack, since it will result in a false negative when comparing `0.0.1` and `v0.0.12` for example. We could easily improve this by using [semver](https://github.com/npm/node-semver) or similar. This does require that we be careful about our tag names, which must be well-formatted version strings.

### Windows
Theoretically this functionality should just work on Windows, but I haven't tested it since we aren't currently supporting Windows.