### PR TITLE
Purges node modules as part of Makefile clean action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ clean:
 	rm -rf release/
 	rm -rf build/icons/*.png
 	rm -rf ansible/roles/geerlingguy.nodejs
+	rm -rf node_modules/
+	rm -rf app/node_modules/
 
 build:
 	make ansible


### PR DESCRIPTION
The `clean-build` dummy command chains together `clean` and `build`.
When bumping versions of the dependencies, it's best not to rely on
cached node assets, but to download them fresh. This makes a dramatic
difference on download size, since a fresh build pulls in roughly half a
gig of dependencies, but it's best to have the clean action incorporate
manual steps to reset the environment than document them separately.