### PR TITLE
Fixes app logo for Linux builds

### DIFF
--- a/ansible/roles/sunder-build/tasks/main.yml
+++ b/ansible/roles/sunder-build/tasks/main.yml
@@ -19,7 +19,7 @@
   command: >
     icns2png --extract
     --output /vagrant/build/icons/
-    /vagrant/build/icons/app.icns
+    /vagrant/build/icon.icns
   args:
     # Use `make clean` in the project root to clear out old icons.
     creates: /vagrant/build/icons/app_32x32x32.png


### PR DESCRIPTION
The `icns2png` command was referencing the old path to the `app.icns`
file, which is no longer valid as of #17 and #24. Fixing that command
allows the icns -> png format conversion work as intended. No changes
required to `package.json`, since the paths there are already correct.

Closes #23.

Signed-off-by: Conor Schaefer <conor@freedom.press>

Behold:

![sunder-app-icon-working-on-linux](https://user-images.githubusercontent.com/657862/26959769-c052d72c-4c86-11e7-968e-bdc0ffcbd53e.png)

Run a `make clean-build` to take advantage of the changes, otherwise the old PNGs will still be used. 