### PR TITLE
Fix linux icons

### DIFF
--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -11,7 +11,7 @@ config.devtool = 'source-map';
 
 config.entry = './src/index';
 
-config.output.publicPath = path.join(__dirname, 'app/dist/');
+config.output.publicPath = './dist/';
 
 config.module.loaders.push({
   test: /\.scss$/,


### PR DESCRIPTION
Fixes #19.

Change webpack's publicPath to be relative.

This fixes linux builds and doesn't break mac builds. I'm not clear on
why they behave differently, but here we are.