### PR TITLE
Quickfix: select copyEl before copying text

### DIFF
--- a/src/components/CopyButton.js
+++ b/src/components/CopyButton.js
@@ -17,6 +17,7 @@ export default class CopyButton extends Component {
 
   handleClicked() {
     let successful;
+    this.copyEl.select();
     this.copyEl.setSelectionRange(0, this.copyEl.value.length);
 
     try {


### PR DESCRIPTION
This is a quickfix for #29. I'm fine with merging this for now, but also think the technique of adding the share text as a hidden input element and using `document.execCommand('copy')` is a bit of a hack, and there might be a cleaner way to do this using Electron's [Clipboard API](https://github.com/electron/electron/blob/master/docs/api/clipboard.md).

@GabeIsman Did you try using Electron's Clipboard API at any point while implementing this feature? Wondering if there's some reason why it wouldn't work (obviously I am fairly novice when it comes to both Electron and React).