### PR TITLE
Creates pardir for app icons under Linux

### DIFF
--- a/ansible/roles/sunder-build/tasks/main.yml
+++ b/ansible/roles/sunder-build/tasks/main.yml
@@ -15,11 +15,25 @@
     - graphicsmagick
     - xz-utils
 
+# PNG icons are only relevant for Linux builds. The app ships with ICNS-format
+# image files, which we'll extract into a subdirectory referred to in the
+# package.json build settings.
+- name: Create parent directory for PNG icons.
+  file:
+    path: /vagrant/build/icons
+    state: directory
+
 - name: Generate PNG-format icons.
   command: >
     icns2png --extract
     --output /vagrant/build/icons/
     /vagrant/build/icon.icns
+  register: icns2png_conversion_result
+  # Maddeningly the `icns2png` program fails silently if it cannot create
+  # the output files! So we have to add manual error handling by inspecting
+  # stderr. Also failing if exit code is non-zero, in case that ever matters.
+  failed_when: icns2png_conversion_result.rc != 0 or
+               'Unable to open' in icns2png_conversion_result.stderr
   args:
     # Use `make clean` in the project root to clear out old icons.
     creates: /vagrant/build/icons/app_32x32x32.png


### PR DESCRIPTION
The previous logic was naively assuming that the parent directory
existed. Bizarrely the `icns2png` command *fails silently* if it cannot
write the output files. :table_flip:

Added a new tasknto create the parent directory, and modified the
icns2png conversion command to catch errors if encountered again in the future.

Closes #32.