### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+Please use the appropriate part of the template: "Bug" or "Feature Request"
+
+# Bug
+
+## Description
+
+A short summary of the issue.
+
+## Steps to Reproduce
+
+A list of clear and easily reproducible step-by-step instructions.
+
+Specify your platform/environment if that is necessary to reproduce the bug (if
+in doubt, include it).
+
+### Expected Behavior
+
+### Actual Behavior
+
+Provide screenshots where appropriate.
+
+## Comments
+
+Suggestions to fix, any other relevant information.
+
+# Feature Request
+
+## Description
+
+A short summary of the idea.
+
+## User Stories
+
+If appropriate. Ideally, a checklist of sentences that have the form "As a <
+type of user >, I want < some goal > so that < some reason >."

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Status
+
+Ready for review / Work in progress
+
+## Description of Changes
+
+Fixes #.
+
+Changes proposed in this pull request:
+
+## Testing
+
+How should the reviewer test this PR?
+Write out any special testing steps here.


### PR DESCRIPTION
@redshiftzero implemented issue and pull request templates on the SecureDrop GitHub repository recently, and after using them for a bit I think the entire SecureDrop team agrees they've been very helpful in encouraging focus and consistency in new issues and pull requests.

This PR adds the issue and pull request templates from the SecureDrop repository, with some slight modifications to make them more appropriate for Sunder:

* Removes SecureDrop-specific notes and reminders.
* Adds more detail to the prompts in some sections, to encourage consistency. 