### PR TITLE
Store and use directory that a shard was saved to.

### DIFF
--- a/src/components/Distribute.js
+++ b/src/components/Distribute.js
@@ -8,13 +8,20 @@ import './Distribute.scss';
 export default class Distribute extends Component {
   static propTypes = {
     shares: PropTypes.array,
-    quorum: PropTypes.number
+    quorum: PropTypes.number,
+    lastDirectory: PropTypes.string,
+    saveLastDirectory: PropTypes.func
   }
 
   render() {
     const { quorum, shares } = this.props;
     const shareRows = this.props.shares.map((share, index) => (
-      <ShareRow key={share} index={index + 1} share={share} />
+      <ShareRow
+        key={share}
+        index={index + 1}
+        lastDirectory={this.props.lastDirectory}
+        saveLastDirectory={this.props.saveLastDirectory}
+        share={share} />
     ));
 
     return (

--- a/src/components/SaveFileButton.js
+++ b/src/components/SaveFileButton.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { remote } from 'electron';
 import fs from 'fs';
+import path from 'path';
 import Button from './Button';
 
 
@@ -11,7 +12,9 @@ export default class SaveFileButton extends Component {
     dialogTitle: PropTypes.string,
     defaultPath: PropTypes.string,
     buttonText: PropTypes.string,
-    onSaved: PropTypes.func
+    onSaved: PropTypes.func,
+    lastDirectory: PropTypes.string,
+    saveLastDirectory: PropTypes.func
   }
 
   constructor(props) {
@@ -20,9 +23,13 @@ export default class SaveFileButton extends Component {
   }
 
   handleClick() {
+    const defaultPath = path.join(
+      this.props.lastDirectory || '',
+      this.props.suggestedFileName);
+
     remote.dialog.showSaveDialog({
       title: this.props.dialogTitle || 'Save File',
-      defaultPath: this.props.defaultPath,
+      defaultPath,
     }, this.filePickerCallback.bind(this));
   }
 
@@ -33,6 +40,8 @@ export default class SaveFileButton extends Component {
     }
 
     this.setState({ save: 'saving', to: filename });
+
+    this.props.saveLastDirectory(path.dirname(filename));
 
     fs.writeFile(
       filename,
@@ -72,5 +81,4 @@ export default class SaveFileButton extends Component {
       </Button>
     );
   }
-
 }

--- a/src/components/ShareRow.js
+++ b/src/components/ShareRow.js
@@ -9,7 +9,9 @@ import './ShareRow.scss';
 export default class ShareRow extends Component {
   static propTypes = {
     share: PropTypes.string,
-    index: PropTypes.number
+    index: PropTypes.number,
+    lastDirectory: PropTypes.string,
+    saveLastDirectory: PropTypes.func
   }
 
   constructor(props) {
@@ -77,7 +79,9 @@ export default class ShareRow extends Component {
           <SaveFileButton contents={share}
             type="small"
             onSaved={this.handleSaved.bind(this)}
-            defaultPath={`secret-shard-${index}.txt`} />
+            lastDirectory={this.props.lastDirectory}
+            saveLastDirectory={this.props.saveLastDirectory}
+            suggestedFileName={`secret-shard-${index}.txt`} />
         </div>
         {this.state.shown && modal}
       </div>

--- a/src/containers/DistributeScreen.js
+++ b/src/containers/DistributeScreen.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import Distribute from '../components/Distribute';
 import HomeButton from '../components/HomeButton';
 import Layout from '../components/Layout';
+import { saveLastDirectory } from '../ducks/files';
 
 export class DistributeScreen extends Component {
   static propTypes = {
@@ -15,6 +16,10 @@ export class DistributeScreen extends Component {
     router: PropTypes.object
   }
 
+  saveLastDirectory(directory) {
+    this.props.dispatch(saveLastDirectory(directory));
+  }
+
   render() {
     if (!this.props.shares) {
       this.context.router.push('/');
@@ -24,7 +29,11 @@ export class DistributeScreen extends Component {
 
     return (
       <Layout header={headerContent} title="Distribute Secret Shards">
-        <Distribute shares={this.props.shares} quorum={this.props.quorum} />
+        <Distribute
+          shares={this.props.shares}
+          quorum={this.props.quorum}
+          lastDirectory={this.props.lastDirectory}
+          saveLastDirectory={this.saveLastDirectory.bind(this)} />
       </Layout>
     );
   }
@@ -33,7 +42,8 @@ export class DistributeScreen extends Component {
 function mapStateToProps(state) {
   return {
     shares: state.split.shares,
-    quorum: state.split.quorum
+    quorum: state.split.quorum,
+    lastDirectory: state.files.lastDirectory
   };
 }
 

--- a/src/ducks/files.js
+++ b/src/ducks/files.js
@@ -1,0 +1,16 @@
+export const SAVE_LAST_DIRECTORY = 'SAVE_LAST_DIRECTORY';
+
+const initialState = {};
+
+export default function reducer(state = initialState, action) {
+  switch (action.type) {
+    case SAVE_LAST_DIRECTORY:
+      return Object.assign({}, state, { lastDirectory: action.directory });
+    default:
+      return state;
+  }
+}
+
+export function saveLastDirectory(directory) {
+  return { type: SAVE_LAST_DIRECTORY, directory };
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,12 +3,14 @@ import { reducer as form } from 'redux-form';
 import { routerReducer as routing } from 'react-router-redux';
 import split from '../ducks/split';
 import recover from '../ducks/recover';
+import files from '../ducks/files';
 
 const rootReducer = combineReducers({
   routing,
   split,
   recover,
-  form
+  form,
+  files
 });
 
 export default rootReducer;

--- a/test/reducers/files.spec.js
+++ b/test/reducers/files.spec.js
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import reducer, {
+  SAVE_LAST_DIRECTORY
+} from 'src/ducks/files';
+
+describe('files reducer', () => {
+  it('should return the right initial state', () => {
+    expect(reducer(undefined, {})).to.be.eql({});
+  });
+
+  it('should save the directory', () => {
+    const action = {
+      type: SAVE_LAST_DIRECTORY,
+      directory: '/this/is/where/I/saved/the/thing'
+    };
+    expect(reducer(undefined, action)).to.be.eql({
+      lastDirectory: action.directory
+    });
+  });
+});
+


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

This changes the behavior of the distribute screen save file dialog, so
that it reopens in the last directory that a shard was saved to,
instead of a random default.

Doing this manually instead of letting the OS do it for us (by passing
`undefined` to defaultPath), lets us still specify a suggested file
name. This is seems to be a limitation of the Electron API.

This code is shockingly verbose 🙃 . 

Fixes #45.

## Testing

Split a secret. Save shard in a non-default location. Save another. Verify that the dialog re-opens in the same place.
