### PR TITLE
Fix Veracrypt-button related layout race condition.

### DIFF
--- a/test/e2e.js
+++ b/test/e2e.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import electronPath from 'electron';
 
 const appPath = path.join(__dirname, '..');
+const delay = time => new Promise(resolve => setTimeout(resolve, time));
 
 describe('main window', function spec() {
   this.timeout(5000);
@@ -86,6 +87,8 @@ describe('main window', function spec() {
 
   it('should click view secret button', async () => {
     await app.client.waitForExist('#view-secret-button');
+    // Wait for flex layout to settle in case Veracrypt button is added.
+    await delay(200);
     await app.client.element('#view-secret-button').click();
   });
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #58.

Adds a small delay between waiting for the Recovery screen to load and clicking on the first button. This is to account for the fact that the asynchronously rendered Veracrypt button (which only shows up if Veracrypt is installed), overlaps with the other buttons for a few milliseconds before the browser flexes it into place.

## Testing

Install Veracrypt CLI. Rebuild the app. Run the e2e tests.
