### PR TITLE
Add Content Security Policy for app

### DIFF
--- a/app.html
+++ b/app.html
@@ -2,6 +2,12 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self';
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:3000/dist/bundle.js;
+        style-src 'self' 'unsafe-inline';
+        connect-src http://localhost:3000;
+        font-src 'self' http://localhost:3000;
+        object-src 'none';">
     <title>Sunder</title>
     <script>
       (function() {


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Initial (though permissive) content security policy for the application. Fixes #83 

Restricting the policy further will require changes to the way the application is bundled:

* `localhost:3000` is allowed for script, connect and font. In the future, a distinct app.html when `npm run dev` is invoked.

* inline/eval are allowed as they are required by `react-boilerplate` (see #78 ) require upstream changes.

## Testing

Ensure all the debug/dev functionality remains when `npm run dev` is invoked.
