### PR TITLE
Fixes for building deb packages under a grsecurity host

### DIFF
--- a/tools/build-sunder-debian-packages.sh
+++ b/tools/build-sunder-debian-packages.sh
@@ -26,7 +26,8 @@ function npm_install() {
 function build() {
     if [ -d /proc/sys/kernel/grsecurity/ ]; then
         # build and hacky re-run for grsec users
-        npm run dist || find /home/node/.cache/ -type f -name ruby -exec paxctl -cm '{}' \;
+        npm run dist || true
+        find /home/node/.cache/ -type f -name ruby -exec paxctl -cm '{}' \;
         npm run dist
     else
         npm run dist

--- a/tools/docker-clean
+++ b/tools/docker-clean
@@ -3,5 +3,5 @@
 if type docker; then \
     docker rmi -f "$(docker images --filter "label=image_name=sunder" --filter "label=org=Freedom of the Press" -q)" 2> /dev/null || echo "No images to clean"
     docker container prune --filter "label=image_name=sunder" --filter "label=org=Freedom of the Press" -f
-    docker volume rm -f fpf-sunder-nodel
+    docker volume rm -f fpf-sunder-node
 fi


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #102 

Changes proposed in this pull request:

* A slight tweak to the bash paxctl tagging behavior under a grsec host
* Fixes a typo in the docker clean logic

## Testing

How should the reviewer test this PR?
1. Are you running under a grsec host ? If yes, continue
2. Run `make clean && make build`
3. You should get a deb produced in the `dist` folder without the docker container bombing out.
