### PR TITLE
More intuitive Makefile targets for testing and packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,14 @@ build-deb: docker-build ## Builds Sunder Debian packages for Linux
 		-v fpf-sunder-node:/sunder/node_modules \
 		sunder-build:latest
 
+.PHONY: npm-install-init
+npm-install-init: ## Installs npm modules locally only if node_modules/ absent
+	if [ ! -d node_modules ] ; then \
+		npm install ; \
+	fi
+
 .PHONY: build-dmg
-build-dmg: ## Builds Sunder DMG and app bundle for macOS (requires macOS)
+build-dmg: npm-install-init ## Builds Sunder DMG and app bundle for macOS (requires macOS)
 	npm run dist
 
 .PHONY: docker-clean
@@ -50,15 +56,15 @@ docs: docs-clean ## Runs livereload environment for local documentation editing
 	sphinx-autobuild docs/ docs/_build/html
 
 .PHONY: build-app
-build-app: ## Packages Electron app locally via webpack for development and testing
+build-app: npm-install-init ## Packages Electron app locally via webpack for development and testing
 	npm run build-app
 
 .PHONY: test-unit
-test-unit: ## Runs unit tests in local dev env
+test-unit: npm-install-init ## Runs unit tests in local dev env
 	npm run test
 
 .PHONY: test-e2e
-test-e2e: build-app ## Runs end-to-end integration tests local dev env
+test-e2e: npm-install-init build-app ## Runs end-to-end integration tests local dev env
 	npm run test-e2e
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,21 @@ docs: docs-clean ## Runs livereload environment for local documentation editing
 # Spins up livereload environment for editing; blocks.
 	sphinx-autobuild docs/ docs/_build/html
 
+.PHONY: build-app
+build-app: ## Packages Electron app locally via webpack for development and testing
+	npm run build-app
+
+.PHONY: test-unit
+test-unit: ## Runs unit tests in local dev env
+	npm run test
+
+.PHONY: test-e2e
+test-e2e: build-app ## Runs end-to-end integration tests local dev env
+	npm run test-e2e
+
+.PHONY: test
+test: test-unit test-e2e ## Runs all unit and integration tests
+
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.
 # 2. Check for second field matching, skip otherwise.

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,17 @@ clean: docker-clean ## Removes all build-related artifacts
 docker-build: ## Builds Docker image for creating Sunder Linux deb packages
 	docker build . --build-arg=UID=$(UID) -t sunder-build
 
-.PHONY: build
-build: docker-build ## Builds Sunder Debian packages for Linux
+.PHONY: build-deb
+build-deb: docker-build ## Builds Sunder Debian packages for Linux
 	docker volume create fpf-sunder-node && \
 	docker run \
 		-v $(PWD):/sunder \
 		-v fpf-sunder-node:/sunder/node_modules \
 		sunder-build:latest
+
+.PHONY: build-dmg
+build-dmg: ## Builds Sunder DMG and app bundle for macOS (requires macOS)
+	npm run dist
 
 .PHONY: docker-clean
 docker-clean: ## Purges Docker images related to building Sunder deb packages

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ prerequisites for the build environment:
 Once you have the prerequisites installed, you should be able to
 
 ```
-make build
+make build-deb
 ```
 
 Packages will be found in `dist/`.
@@ -45,7 +45,7 @@ Packages will be found in `dist/`.
 To package up the app for your current platform (e.g. OS X):
 
 ```
-npm run dist
+make build-dmg
 ```
 
 Note that this will run `build-app` so there's no need to run that beforehand.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ If you get an error from `node-gyp` during `npm install`, note that it expects `
 
 ### Testing
 
-- To run the unit tests: `npm run test`
+- To run the unit tests: `make test-unit`
 - For development you might enjoy the continuously updating tests: `npm run test-watch`
-- The end-to-end integration suite can be run with `npm run test-e2e`. Note that this runs agains built code, so an `npm run build-app` is prudent and/or necessary.
+- The end-to-end integration suite can be run with `make test-e2e`.
+  Note that this runs agains built code, so `npm run build-app` will run beforehand.
+- To run all tests, use `make test`. Again, `npm run build-app` will run before the integration tests.
 
 ## Building
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,8 +3,5 @@ machine:
     version: 8.2.0
 
 test:
-  pre:
-    - npm run build-app
   override:
-    - npm run test
-    - npm run test-e2e
+    - make test


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

Dev-env only changes designed to make testing and packaging more straightforward. Includes some docs changes to track the new Makefile targets, and consolidated all the CI steps into a single `make test`. 

Trying to reduce the opportunities for error in both testing and packaging steps.

## Testing

Take the new targets for a spin and report any problems. Double-check that the docs are clear, and not confusing.