### PR TITLE
Bump moment to 2.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,7 +2694,7 @@
         "commander": "2.6.0",
         "cross-spawn": "0.2.9",
         "lodash": "4.17.4",
-        "moment": "2.19.2",
+        "moment": "2.21.0",
         "rx": "2.3.24"
       },
       "dependencies": {
@@ -5518,7 +5518,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -7830,9 +7831,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "minimist": "^1.2.0",
     "mocha": "^3.3.0",
     "mockery": "^1.6.2",
+    "moment": "^2.19.3",
     "node-sass": "^3.4.2",
     "nyc": "^10.3.0",
     "react-addons-test-utils": "^15.0.0",


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Moment is affected by CVE2017-18214 (DoS via crafted date string). Not only is it a dev dependency, sunder does not use this functionality and therefore shouldn't be affected. To avoid receiving and ignoring security notifications, version bump of concurrently is non-trivial and requires code changes. Overriding and bumping version of moment to 2.9.3 in `package.json` appears to be an easy fix.

## Testing

`npm run test-e2e` on all platforms should suffice.