### PR TITLE
Recover: add filename of share

### DIFF
--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -65,10 +65,10 @@ export default class FileInput extends Component {
 
         // The order of these statements is important because of `componentWillReceiveProps`
         if (this.props.field) {
-          this.props.field.onChange(contents);
+          this.props.field.onChange(contents, file.name);
         }
         if (this.props.onChange) {
-          this.props.onChange(contents);
+          this.props.onChange(contents, file.name);
         }
         if (!this.props.noStatus) {
           this.setState({ filename: file.name });

--- a/src/components/RecoverStatusShare.js
+++ b/src/components/RecoverStatusShare.js
@@ -9,6 +9,7 @@ export class RecoverStatusShare extends Component {
   static propTypes = {
     share: PropTypes.shape({
       data: PropTypes.string.isRequired,
+      filename: PropTypes.string,
       error: PropTypes.string,
     }),
     current: PropTypes.bool,
@@ -33,10 +34,10 @@ export class RecoverStatusShare extends Component {
       statusMessage = 'Share still needed';
     } else if (share.error) {
       className = 'error';
-      statusMessage = `Share #${index + 1}: ${share.error}`;
+      statusMessage = `Share #${index + 1} [${share.filename}]: ${share.error}`;
     } else {
       className = 'success';
-      statusMessage = `Share #${index + 1} succesfully processed`;
+      statusMessage = `Share #${index + 1} [${share.filename}] succesfully processed`;
     }
 
     return (

--- a/src/containers/RecoverScreen.js
+++ b/src/containers/RecoverScreen.js
@@ -56,9 +56,9 @@ export class RecoverScreen extends Component {
     return Promise.all([this.props.dispatch(recover()), delayPromise]);
   }
 
-  handleShareAdded(data) {
+  handleShareAdded(data, filename) {
     const share = Buffer.isBuffer(data) ? data.toString('utf8') : data;
-    this.props.dispatch(addShare(share));
+    this.props.dispatch(addShare(share, filename));
   }
 
   handleReset() {

--- a/src/ducks/recover.js
+++ b/src/ducks/recover.js
@@ -38,13 +38,16 @@ export default function reducer(state = initialState, action) {
       const shareProperties =
         Object.assign({}, action.shareProperties, state.shareProperties);
       return Object.assign({}, state, {
-        shares: [...state.shares, { data: action.share }],
+        shares: [...state.shares, { data: action.share, filename: action.filename }],
         shareProperties
       });
     }
     case BAD_SHARE:
       return Object.assign({}, state, {
-        shares: [...state.shares, { data: action.share, error: action.error }]
+        shares: [
+          ...state.shares,
+          { data: action.share, filename: action.filename, error: action.error }
+        ]
       });
     case REMOVE_SHARE:
       // If this is the only share, completely reset.
@@ -118,33 +121,34 @@ function errorReducer(state, action) {
 }
 
 
-export function addShare(share) {
+export function addShare(share, filename) {
   return (dispatch, getState) => {
     const state = getState();
     const result = validateShare(share, state.recover.shares);
 
     if (result.error === 'DUPLICATE') {
-      return dispatch(badShare(share, 'Duplicate share'));
+      return dispatch(badShare(share, filename, 'Duplicate share'));
     }
 
     if (result.error === 'MALFORMED') {
-      return dispatch(badShare(share, 'Malformed share'));
+      return dispatch(badShare(share, filename, 'Malformed share'));
     }
 
     if (result.error) {
-      return dispatch(badShare(share, 'Unknown error'));
+      return dispatch(badShare(share, filename, 'Unknown error'));
     }
 
     dispatch({
       type: ADD_SHARE,
       share,
+      filename,
       shareProperties: { quorum: result.parsedShare.quorum }
     });
   };
 }
 
-export function badShare(share, error) {
-  return { type: BAD_SHARE, share, error };
+export function badShare(share, filename, error) {
+  return { type: BAD_SHARE, share, filename, error };
 }
 
 


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Implements feature request #124: the filename of the share is displayed after importing it.

Changes proposed in this pull request:
 - add the filename of a share as a parameter from `FileInput` all the way to `RecoverStatusShare`

## Testing

I'm kind of new to JavaScript and Node.js/Electron, so please let me know if I'm doing any bad practices.

I've noticed `FileInput` is used by `FileOrTextInput` as well. I have added a parameter to the `onChange` callback but I don't think there is any interference.

Thanks!