### PR TITLE
Avoid uncaught error when recovery fails

### DIFF
--- a/src/lib/crypto.js
+++ b/src/lib/crypto.js
@@ -61,12 +61,12 @@ export function recoverFFI(shares) {
     cryptoFFI.wrapped.recoverSecret(
       shares,
       SIGN_SHARES, // Verify signatures if shares have been signed
-      (err, { secret, mimeType }) => {
+      (err, result) => {
       if (err) {
         return reject(err);
       }
 
-      resolve(secret);
+      resolve(result.secret);
     });
   });
 }


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #128.

If recovery fails, the callback from recoverSecret is invoked with two
arguments: `(error, undefined)`. Trying to expand an undefined input to a
{ secret, mimeType } causes an uncaught TypeError, which effectively
blocks updating the app state/UI.

## Testing

Use sunder to generate two sets of sharded secrets with the same parameters (e.g., 2/3 shards required).

From the Recover screen, select one shard from each set. Then click Recover.

The UI should revert to the Recover screen and show an error on one of the shards.