### PR TITLE
Add Save All button to save secrets

### DIFF
--- a/src/components/Distribute.js
+++ b/src/components/Distribute.js
@@ -1,8 +1,12 @@
 import React, { Component } from 'react';
+const { clipboard } = require('electron');
+import { remote } from 'electron';
+import fs from 'fs';
 import PropTypes from 'prop-types';
 import ShareRow from './ShareRow';
 import Panel from './Panel';
 import Info from './Info';
+import Button from './Button';
 import './Distribute.scss';
 
 export default class Distribute extends Component {
@@ -11,15 +15,103 @@ export default class Distribute extends Component {
     quorum: PropTypes.number
   }
 
+  constructor(props) {
+    super(props);
+    this.state = { copiedShare: null, saveStatuses: [] };
+  }
+
+  copyShare(index) {
+    clipboard.writeText(this.props.shares[index]);
+
+    window.clearTimeout(this.state.timeoutCallback);
+    var timeoutCallback = window.setTimeout(() => this.setState({ copiedShare: null }), 5000);
+
+    this.setState({ copiedShare: index, timeoutCallback });
+  }
+
+  saveShare(index) {
+    remote.dialog.showSaveDialog({
+      title: 'Save share',
+      defaultPath: `secret-share-${index + 1}.txt`,
+    }, (filename) => {
+      if (!filename) {
+        return;
+      }
+      this.writeShare(index, filename);
+    });
+  }
+
+  saveAllShares() {
+    remote.dialog.showOpenDialog({
+      title: 'Save All Files',
+      properties: ['openDirectory', 'createDirectory']
+    }, (directory) => {
+      if (!directory) {
+        return;
+      }
+      this.props.shares.forEach((item, index) => {
+        this.writeShare(
+          index,
+          `${directory}/secret-share-${index + 1}.txt`,
+          false
+        );
+      });
+    });
+  }
+
+  writeShare(index, filename, overwrite = true) {
+    fs.writeFile(
+      filename,
+      this.props.shares[index],
+      { mode: '0600', flag: (overwrite ? 'w' : 'wx') },
+      (error) => {
+        let saveStatus = {};
+
+        if (error) {
+          saveStatus.isError = true;
+          saveStatus.text = 'Save failed';
+
+          switch (error.code) {
+            case 'EEXIST':
+              saveStatus.toolTip = 'File already exists.';
+              break;
+            default:
+              saveStatus.toolTip = `Unexpected error: ${error.code}.`;
+              break;
+          }
+        } else {
+          saveStatus.text = 'Save successful';
+          saveStatus.toolTip = `Saved as: ${filename}`;
+        }
+
+        this.setState((prevState) => {
+          prevState.saveStatuses[index] = saveStatus;
+        });
+      }
+    );
+  }
+
   render() {
     const { quorum, shares } = this.props;
-    const shareRows = this.props.shares.map((share, index) => (
-      <ShareRow key={share} index={index + 1} share={share} />
+    const { copiedShare, saveStatuses } = this.state;
+
+    const shareRows = shares.map((share, index) => (
+      <ShareRow key={share}
+        shareNumber={index + 1}
+        isCopied={copiedShare === index}
+        saveStatus={saveStatuses[index]}
+        onClickCopy={this.copyShare.bind(this, index)}
+        onClickSave={this.saveShare.bind(this, index)} />
     ));
 
     return (
       <div className="container distribute-container flex-column">
         <Panel title="Secret Shares">
+          <Button type="default"
+            icon="hdd-o"
+            onClick={this.saveAllShares.bind(this)}>
+            Save all
+          </Button>
           <div className="shares-table">
             {shareRows}
           </div>

--- a/src/components/ShareRow.js
+++ b/src/components/ShareRow.js
@@ -1,59 +1,55 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import CopyButton from './CopyButton';
-import SaveFileButton from './SaveFileButton';
+import Button from './Button';
 import './ShareRow.scss';
 
 export default class ShareRow extends Component {
   static propTypes = {
-    share: PropTypes.string,
-    index: PropTypes.number
-  }
-
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
-
-  handleCopied() {
-    this.setState({ copied: true });
-  }
-
-  handleSaved(filename) {
-    this.setState({ saved: filename });
+    shareNumber: PropTypes.number.isRequired,
+    isCopied: PropTypes.bool,
+    saveStatus: PropTypes.shape({
+      text: PropTypes.string,
+      toolTip: PropTypes.string,
+      isError: PropTypes.bool,
+    }),
+    onClickCopy: PropTypes.func.isRequired,
+    onClickSave: PropTypes.func.isRequired,
   }
 
   render() {
-    const { share, index } = this.props;
-    let savedIndicator = '';
+    const { shareNumber, saveStatus } = this.props;
+    let statusText = '';
 
-    if (this.state.saved) {
-      savedIndicator = (
-        <span className="tooltipped bottom-tooltip right-tooltip"
-          data-tooltip={this.state.saved}>
-          saved
+    if (saveStatus) {
+      statusText = (
+        <span className={`share-status ${(saveStatus.isError ? 'error' : '')}`}>
+          <span className="tooltipped bottom-tooltip right-tooltip"
+            data-tooltip={saveStatus.toolTip}>
+            {saveStatus.text}
+          </span>
         </span>
       );
     }
 
     return (
-      <div className="share-row" key={share} id={`share-${index}`}>
+      <div className="share-row" id={`share-${shareNumber}`}>
         <div className="share-cell share-value">
-          {`Share #${index}`}
-          <span className="share-status">
-            {this.state.copied ? 'copied' : ''}
-            {this.state.copied && this.state.saved ? ', ' : ''}
-            {savedIndicator}
-          </span>
+          {`Share #${shareNumber}`}
+          {statusText}
         </div>
         <div className="share-cell share-actions">
-          <CopyButton type="small"
-            targetText={share}
-            onCopied={this.handleCopied.bind(this)} />
-          <SaveFileButton contents={share}
+          <Button className="copy"
             type="small"
-            onSaved={this.handleSaved.bind(this)}
-            defaultPath={`secret-shard-${index}.txt`} />
+            icon="clipboard"
+            onClick={this.props.onClickCopy}>
+            {this.props.isCopied ? 'Copied' : 'Copy'}
+          </Button>
+          <Button className="save"
+            type="small"
+            icon="hdd-o"
+            onClick={this.props.onClickSave}>
+            {saveStatus && !saveStatus.isError ? 'Saved' : 'Save'}
+          </Button>
         </div>
       </div>
     );

--- a/src/components/ShareRow.scss
+++ b/src/components/ShareRow.scss
@@ -46,4 +46,8 @@
   margin-left: 10px;
   font-size: 12px;
   color: $green;
+
+  &.error {
+    color: $red;
+  }
 }


### PR DESCRIPTION
## Status

Ready for review / Work in progress

## Description of Changes

Fixes #88 

Added a Save All button to the distribute view. To achieve this logic is moved from `CopyButton`, `SaveAllButton` and `ShareRow` up to `Distribute`.

Because it can happen that most shares save successfully and only some fail, I wanted to display the status of every share individually. I opted to display the status of every save action in the share row itself.

Implementation:

 - I've moved the copy and save logic into `Distribute.js`.
 - Save All does the same as if you saved each of share one-by-one and the error handling is exactly the same.
 - With Save All you can't choose the filename. Because this might overwrite an existing file Save All fails if the file already exists.
 - I've moved the 'Save failed' field to the status text, this is more clear imo and allows us to show specific errors in the tooltip.
 - When copying, only one copy button will indicate "Copied" and it will return to default after 5 seconds.
 - Due to these changes `ShareRow` is basically reduced to rendering, `CopyButton` and `SaveFileButton` is not used anymore in this view.

## Possible improvements

 - Improve styling of the Save All button. It kind of dissappears now in the panel now. Maybe give it a colour?
 - Some general refactoring is probably also possible...

## Testing

Try copying and saving some shares.