### PR TITLE
Add Save All button, refactor UI to display save errors

### DIFF
--- a/src/components/Distribute.js
+++ b/src/components/Distribute.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import SaveAllButton from './SaveAllButton';
 import ShareRow from './ShareRow';
 import Panel from './Panel';
 import Info from './Info';
@@ -11,15 +12,40 @@ export default class Distribute extends Component {
     quorum: PropTypes.number
   }
 
+  constructor(props) {
+    super(props);
+    this.state = { saveStatus: [] };
+  }
+
+  onSaved(index, saveStatus) {
+    this.setState((state) => {
+      state.saveStatus[index] = saveStatus;
+    });
+  }
+
+  onSavedAll(saveStatuses) {
+    this.setState({
+      saveStatus: saveStatuses
+    });
+  }
+
   render() {
     const { quorum, shares } = this.props;
+
     const shareRows = this.props.shares.map((share, index) => (
-      <ShareRow key={share} index={index + 1} share={share} />
+      <ShareRow key={share}
+        shareNr={index + 1}
+        share={share}
+        saved={this.state.saveStatus[index]}
+        onSaved={this.onSaved.bind(this, index)} />
     ));
 
     return (
       <div className="container distribute-container flex-column">
         <Panel title="Secret Shares">
+          <SaveAllButton type="small"
+            contents={shares}
+            onSavedAll={this.onSavedAll.bind(this)} />
           <div className="shares-table">
             {shareRows}
           </div>

--- a/src/components/SaveAllButton.js
+++ b/src/components/SaveAllButton.js
@@ -1,32 +1,36 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { saveFile } from 'src/lib/save';
+import { saveFiles } from 'src/lib/save';
 import Button from './Button';
 
 
-export default class SaveFileButton extends Component {
+export default class SaveAllButton extends Component {
   static propTypes = {
-    contents: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    contents: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string, PropTypes.object
+      ])
+    ),
     saveOptions: PropTypes.object,
     isSaved: PropTypes.bool,
-    onSaved: PropTypes.func,
+    onSavedAll: PropTypes.func,
   }
 
   handleClick() {
-    saveFile(
+    saveFiles(
       this.props.contents,
       this.props.saveOptions,
-      this.props.onSaved
+      this.props.onSavedAll
     );
   }
 
   render() {
     return (
-      <Button
+      <Button type="default"
         onClick={this.handleClick.bind(this)}
         icon="hdd-o"
         {...this.props}>
-        {this.props.isSaved ? "Saved" : "Save"}
+        {this.props.isSaved ? "Saved all" : "Save all"}
       </Button>
     );
   }

--- a/src/components/ShareRow.js
+++ b/src/components/ShareRow.js
@@ -7,7 +7,12 @@ import './ShareRow.scss';
 export default class ShareRow extends Component {
   static propTypes = {
     share: PropTypes.string,
-    index: PropTypes.number
+    shareNr: PropTypes.number,
+    saved: PropTypes.shape({
+      success: PropTypes.bool,
+      message: PropTypes.string,
+    }),
+    onSaved: PropTypes.func,
   }
 
   constructor(props) {
@@ -19,30 +24,26 @@ export default class ShareRow extends Component {
     this.setState({ copied: true });
   }
 
-  handleSaved(filename) {
-    this.setState({ saved: filename });
-  }
-
   render() {
-    const { share, index } = this.props;
+    const { share, shareNr, saved } = this.props;
     let savedIndicator = '';
 
-    if (this.state.saved) {
+    if (saved) {
       savedIndicator = (
-        <span className="tooltipped bottom-tooltip right-tooltip"
-          data-tooltip={this.state.saved}>
-          saved
+        <span className={`tooltipped bottom-tooltip right-tooltip ${saved.success ? '' : 'error'}`}
+          data-tooltip={saved.message}>
+          {saved.success ? 'saved' : 'save failed'}
         </span>
       );
     }
 
     return (
-      <div className="share-row" key={share} id={`share-${index}`}>
+      <div className="share-row" key={share} id={`share-${shareNr}`}>
         <div className="share-cell share-value">
-          {`Share #${index}`}
+          {`Share #${shareNr}`}
           <span className="share-status">
             {this.state.copied ? 'copied' : ''}
-            {this.state.copied && this.state.saved ? ', ' : ''}
+            {this.state.copied && this.props.saved ? ', ' : ''}
             {savedIndicator}
           </span>
         </div>
@@ -50,10 +51,13 @@ export default class ShareRow extends Component {
           <CopyButton type="small"
             targetText={share}
             onCopied={this.handleCopied.bind(this)} />
-          <SaveFileButton contents={share}
-            type="small"
-            onSaved={this.handleSaved.bind(this)}
-            defaultPath={`secret-shard-${index}.txt`} />
+          <SaveFileButton type="small"
+            contents={share}
+            isSaved={saved && saved.success}
+            onSaved={this.props.onSaved}
+            saveOptions={{
+              shareNr: shareNr,
+            }} />
         </div>
       </div>
     );

--- a/src/components/ShareRow.scss
+++ b/src/components/ShareRow.scss
@@ -47,3 +47,7 @@
   font-size: 12px;
   color: $green;
 }
+
+.error {
+  color: $red;
+}

--- a/src/lib/save.js
+++ b/src/lib/save.js
@@ -1,0 +1,84 @@
+import { remote } from 'electron';
+import fs from 'fs';
+
+const DEFAULT_FILENAME_FN = (shareNr) => `secret-share-${shareNr}.txt`;
+
+/**
+ * @param   {Buffer}    file                  The file to save
+ * @param   {Object}    options
+ * @param   {Object}    options.dialogTitle   Title of dialog window
+ * @param   {Object}    options.defaultPath   Directory or filename to use by default
+ * @param   {Function}  options.shareNr       If no defaultPath is supplied, the share number to generate
+ *                                            the filename with
+ * @param   {Function}  callback              Called after save action with object { success, message }
+ */
+export function saveFile(file, options = {}, callback) {
+  remote.dialog.showSaveDialog({
+    title: options.dialogTitle || 'Save File',
+    defaultPath: options.defaultPath || (options.shareNr ? DEFAULT_FILENAME_FN(options.shareNr) : undefined),
+  }, (filename) => {
+    let result;
+
+    if (!filename) {
+      return;
+    }
+
+    result = writeFile(filename, file);
+
+    callback(result);
+  });
+}
+
+/**
+ * @param   {Array}     files                 Array with files to save
+ * @param   {Object}    options
+ * @param   {Object}    options.dialogTitle   Title of dialog window
+ * @param   {Object}    options.defaultPath   Directory to use by default
+ * @param   {Function}  options.filenameFn    Function to generate a custom filename, accepts a Number
+ *                                            (share number) and returns String
+ * @param   {Function}  callback              Called after save action with array of object { success, message }
+ */
+export function saveFiles(files, options = {}, callback) {
+  remote.dialog.showOpenDialog({
+    title: options.dialogTitle || 'Save All Files',
+    defaultPath: options.defaultPath,
+    properties: ['openDirectory', 'createDirectory']
+  }, (directory) => {
+    let result = [];
+    let filenameFn = options.filenameFn || DEFAULT_FILENAME_FN;
+
+    if (!directory) {
+      return;
+    }
+
+    files.forEach((file, index) => {
+      let filename = `${directory}/${filenameFn(index + 1)}`;
+      result[index] = writeFile(filename, file, false);
+    });
+
+    callback(result);
+  });
+}
+
+/**
+ * @param   {String}    filename
+ * @param   {Buffer}    file
+ * @param   {bool}      overwrite             Whether to overwrite file if filename already exists
+ * @returns {Object}    Object containing: success {bool} and message {String}
+ */
+function writeFile(filename, file, overwrite = true)
+{
+  try {
+    fs.writeFileSync(
+      filename,
+      file,
+      { mode: '0600', flag: (overwrite ? 'w' : 'wx') }
+    );
+    return { success: true, message: filename };
+  } catch (error) {
+    if (error.code === 'EEXIST')
+      return { success: false, message: 'File already exists' };
+    else
+      return { success: false, message: `Unknown error: ${error.code}` };
+  }
+}


### PR DESCRIPTION
## Status

Ready for review / Feedback welcome!

## Description of Changes

Implements #88 
This is a "rework" of #132

Changes proposed in this pull request:

 - rename `index` to `shareNr` when not using zero-based numbering, for clarity
 - move all save functionality to `lib\save.js`
 - move save status to the common parent of all save buttons: `Distribute.js`, this information is passed to `ShareRow` as prop
 - add SaveAllButton

## Possible improvements

 - Improve styling of the Save All button. It kind of disappears now in the panel now. Maybe give it a colour?

## Testing

Try copying and saving some shares.