### PR TITLE
added doc-lint to make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-e2e: npm-install-init build-app ## Runs end-to-end integration tests local 
 	npm run test-e2e
 
 .PHONY: test
-test: test-unit test-e2e ## Runs all unit and integration tests
+test: test-unit test-e2e docs-lint ## Runs all unit and integration tests
 
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-e2e: npm-install-init build-app ## Runs end-to-end integration tests local 
 	npm run test-e2e
 
 .PHONY: test
-test: test-unit test-e2e docs-lint ## Runs all unit and integration tests
+test: test-unit test-e2e ## Runs all unit and integration tests
 
 # Explanation of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" to parse lines for make targets.

--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,4 @@ dependencies:
 test:
   override:
     - make test
+    - make docs-lint


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes
Fixes #119 
Doc-linting along with running tests in CI

## Testing
Running `make test` now runs docs-lint as part of the testing process and fails if there's any error in the compilation of the docs. This will enable automatically docs linting by CI when PR is raised 