### PR TITLE
Update mocha to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,24 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "7zip-bin-linux": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
-      "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
-      "dev": true,
-      "optional": true
-    },
     "7zip-bin-mac": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
       "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
-      "dev": true,
-      "optional": true
-    },
-    "7zip-bin-win": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
-      "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ==",
       "dev": true,
       "optional": true
     },
@@ -169,7 +155,7 @@
     "ansi-escape-sequences": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
-      "integrity": "sha512-v+0wW9Wezwsyb0uF4aBVCjmSqit3Ru7PZFziGF0o2KwTvN2zWfTi3BRLq9EkJFdg3eBbyERXGTntVpBxH1J68Q==",
+      "integrity": "sha1-4OywQpWLceQpQtNcH88dmwCg9n4=",
       "requires": {
         "array-back": "2.0.0"
       }
@@ -414,7 +400,7 @@
     "array-back": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+      "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
       "requires": {
         "typical": "2.6.1"
       }
@@ -1841,7 +1827,7 @@
         "hoek": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
           "dev": true
         }
       }
@@ -2049,9 +2035,7 @@
           "integrity": "sha512-QU3oR1dLLVrYGRkb7LU17jMCpIkWtXXW7q71ECXWXkR9vOv37VjykqpvFgs29HgSCNLZHnNKJzdG6RwAW0LwIA==",
           "dev": true,
           "requires": {
-            "7zip-bin-linux": "1.3.1",
-            "7zip-bin-mac": "1.0.1",
-            "7zip-bin-win": "2.1.1"
+            "7zip-bin-mac": "1.0.1"
           }
         },
         "ansi-styles": {
@@ -2576,7 +2560,7 @@
     "command-line-args": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-4.0.7.tgz",
-      "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
+      "integrity": "sha1-+NGRbsuQ6eEh7aZCjkEwC/tkzEY=",
       "requires": {
         "array-back": "2.0.0",
         "find-replace": "1.0.3",
@@ -2586,7 +2570,7 @@
     "command-line-commands": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/command-line-commands/-/command-line-commands-2.0.1.tgz",
-      "integrity": "sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==",
+      "integrity": "sha1-xYqhPceMBgOO1nB35XrQmm+Fj0Y=",
       "requires": {
         "array-back": "2.0.0"
       }
@@ -2594,7 +2578,7 @@
     "command-line-usage": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "integrity": "sha1-prOy4nA7Tc+L1GrhnhGKmlKXKII=",
       "requires": {
         "ansi-escape-sequences": "4.0.0",
         "array-back": "2.0.0",
@@ -3000,7 +2984,7 @@
             "hoek": {
               "version": "4.2.1",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+              "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
               "dev": true
             }
           }
@@ -3379,9 +3363,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dirty-chai": {
@@ -3849,9 +3833,7 @@
           "integrity": "sha512-QU3oR1dLLVrYGRkb7LU17jMCpIkWtXXW7q71ECXWXkR9vOv37VjykqpvFgs29HgSCNLZHnNKJzdG6RwAW0LwIA==",
           "dev": true,
           "requires": {
-            "7zip-bin-linux": "1.3.1",
-            "7zip-bin-mac": "1.0.1",
-            "7zip-bin-win": "2.1.1"
+            "7zip-bin-mac": "1.0.1"
           }
         },
         "ansi-styles": {
@@ -4454,7 +4436,7 @@
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
       "dev": true
     },
     "es6-set": {
@@ -5572,7 +5554,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -6286,16 +6269,10 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "handlebars": {
@@ -6380,7 +6357,7 @@
         "hoek": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
           "dev": true
         }
       }
@@ -6405,7 +6382,7 @@
     "hoek": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+      "integrity": "sha1-tx1A2UPQqV2gGVa1R/g8SltKNKw=",
       "dev": true
     },
     "hoist-non-react-statics": {
@@ -7118,12 +7095,6 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
@@ -7339,12 +7310,6 @@
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
     "lodash._basefor": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
@@ -7427,17 +7392,6 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      }
     },
     "lodash.deburr": {
       "version": "3.2.0",
@@ -7852,47 +7806,49 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
         "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+          "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+          "dev": true
+        },
         "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -7903,13 +7859,19 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -7952,7 +7914,7 @@
     "neon-cli": {
       "version": "0.1.22",
       "resolved": "https://registry.npmjs.org/neon-cli/-/neon-cli-0.1.22.tgz",
-      "integrity": "sha512-347dLid0g82Jc/wD0crX2sRXBdcu7fnZdlUVCE96xrjoJBqhgKxCB/3+W+jYPtI1x5nl9vWIqcHbiD8PhlwdVw==",
+      "integrity": "sha1-Gy7Ml4zUIazEepEl+Hahpte68O8=",
       "requires": {
         "chalk": "2.1.0",
         "command-line-args": "4.0.7",
@@ -7993,7 +7955,7 @@
         "chalk": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -8016,7 +7978,7 @@
         "inquirer": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.1.0",
@@ -8060,7 +8022,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -11616,7 +11578,7 @@
     "rusty-secrets": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/rusty-secrets/-/rusty-secrets-0.3.0.tgz",
-      "integrity": "sha512-vDzT6S7JEGi4jN69h+7FGIFuaoJeFYyqv6achfGm5dkVJD2vPITIdM2GbF61p7QMRgdElNU09WhbbNQqJOsrPw==",
+      "integrity": "sha1-RbnT13dZMmChQceDhF3aPtSNOz4=",
       "requires": {
         "neon-cli": "0.1.22"
       }
@@ -11948,7 +11910,7 @@
         "hoek": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs=",
           "dev": true
         }
       }
@@ -12618,7 +12580,7 @@
     "toml": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs="
     },
     "touch": {
       "version": "0.0.3",
@@ -12699,7 +12661,7 @@
         "rsvp": {
           "version": "3.6.2",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-          "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+          "integrity": "sha1-LpZJFZmpbN4bUV1WdKj3qRRSkmo="
         }
       }
     },
@@ -13517,7 +13479,7 @@
     "wordwrapjs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
       "requires": {
         "reduce-flatten": "1.0.1",
         "typical": "2.6.1"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jsdom": "^8.4.0",
     "json-loader": "^0.5.4",
     "minimist": "^1.2.0",
-    "mocha": "^3.3.0",
+    "mocha": "^5.2.0",
     "mockery": "^1.6.2",
     "moment": "^2.19.3",
     "neon-cli": "^0.1.22",


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes a repo security warning about insecure version of growl.

Mocha depends on growl. Growl before 1.10.2 does not properly sanitize
input before passing it to exec, allowing for arbitrary command
execution (CVE-2017-16042).

This doesn't affect Sunder's security, since mocha is only used in
tests, but it's nice to be up to date and to remove the warning about
a vulnerable dependency from our github repo.

## Testing

`make test`