### PR TITLE
Fixes #97: Clears remaining FileInput component state on rerendering

### DIFF
--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -71,6 +71,7 @@ export default class FileInput extends Component {
       <div className={`file-input-container ${this.props.className}`}>
         <input name={this.fileInputId}
           id={this.fileInputId}
+          value=""
           type="file"
           onChange={this.onFileChange.bind(this)}
           multiple={this.props.allowMultiple ? 'multiple' : ''} />

--- a/src/components/FileInput.js
+++ b/src/components/FileInput.js
@@ -23,7 +23,7 @@ export default class FileInput extends Component {
   }
 
   onFileSelection() {
-    let options = {properties: ['openfile']}
+    let options = {properties: ['openFile']}
     if (this.props.allowMultiple) options.properties.push('multiSelections');
     const fileList = dialog.showOpenDialog(options);
     if (fileList === undefined) return;


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #97 

Clears out the value attribute on the file input element when it gets rerendered. Leftover values from a previous file can prevent the change event from being fired when it's expected to.