### PR TITLE
Added validation deferral to submission when creating shares

### DIFF
--- a/src/components/FileOrTextInput.js
+++ b/src/components/FileOrTextInput.js
@@ -10,7 +10,8 @@ export default class FileOrTextInput extends Component {
   static propTypes = {
     // redux-form field
     field: PropTypes.object,
-    defaultMode: PropTypes.string
+    defaultMode: PropTypes.string,
+    submittedOnce: PropTypes.bool
   }
 
   constructor(props) {
@@ -49,8 +50,8 @@ export default class FileOrTextInput extends Component {
   }
 
   render() {
-    const { field } = this.props;
-    const hasError = field.touched && field.invalid;
+    const { submittedOnce, field } = this.props;
+    const hasError = submittedOnce && field.invalid;
     const { entryMode } = this.state;
 
     const tooLargeToDisplay = field.value && field.value.length * 2 > MAX_DISPLAY_SIZE_BYTES;

--- a/src/components/NumberField.js
+++ b/src/components/NumberField.js
@@ -8,7 +8,8 @@ import './Field.scss';
 export default class NumberField extends Component {
   static propTypes = {
     field: PropTypes.object,
-    label: PropTypes.string
+    label: PropTypes.string,
+    submittedOnce: PropTypes.bool
   };
 
   onChange(event) {
@@ -16,8 +17,8 @@ export default class NumberField extends Component {
   }
 
   render() {
-    const { field, label } = this.props;
-    const hasError = field.touched && field.invalid;
+    const { field, label, submittedOnce } = this.props;
+    const hasError = submittedOnce && field.invalid;
 
     return (
       <div className={`field-container ${hasError ? 'has-error' : ''}`}>

--- a/src/components/Split.js
+++ b/src/components/Split.js
@@ -10,6 +10,20 @@ import Icon from './Icon';
 import { reduxForm } from 'redux-form';
 import './Split.scss';
 
+function initialValidationWrapper(handler) {
+  return function (...args) {
+    if (!this.state.submittedOnce) {
+      const fields = this.props.fields;
+      const invalid = Object.keys(fields).reduce((acc, field) => (acc || fields[field].invalid), false);
+      this.setState({
+        submittedOnce: true
+      });
+      if (invalid) return;
+    }
+    handler(...args);
+  }
+}
+
 export class Split extends Component {
   // These are all injected by the reduxForm decorator
   static propTypes = {
@@ -23,29 +37,38 @@ export class Split extends Component {
     invalid: PropTypes.bool,
   }
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      submittedOnce: false
+    }
+    this.wrappedHandler = initialValidationWrapper(props.handleSubmit).bind(this);
+  }
+
   render() {
     const {
       fields: { shares, quorum, secret },
       submitting,
-      handleSubmit,
       invalid
     } = this.props;
+
+    const { submittedOnce } = this.state;
 
     return (
       <div className="container flex-column split-container">
         <Panel title="Enter Your Secret">
-          <FileOrTextInput disabled={submitting} field={secret} />
+          <FileOrTextInput disabled={submitting} field={secret} submittedOnce={submittedOnce}/>
         </Panel>
         <Panel title="Share Options" className="split-options-panel">
-          <SplitOptions disabled={submitting}
+          <SplitOptions disabled={submitting} submittedOnce={submittedOnce}
             sharesField={shares} quorumField={quorum} />
         </Panel>
         <div className="flex-row split-button-container">
           <Button type="primary"
             icon={<Icon className="split" />}
             id="create-shares"
-            disabled={invalid || submitting}
-            onClick={handleSubmit}>
+            disabled={submittedOnce && (invalid || submitting)}
+            onClick={this.wrappedHandler}>
             Create Secret Shares
           </Button>
           {submitting && <WorkingIndicator />}

--- a/src/components/SplitOptions.js
+++ b/src/components/SplitOptions.js
@@ -9,11 +9,12 @@ export default class SplitOptions extends Component {
     dispatch: PropTypes.func,
     // reduxForm fields
     quorumField: PropTypes.object,
-    sharesField: PropTypes.object
+    sharesField: PropTypes.object,
+    submittedOnce: PropTypes.bool
   }
 
   render() {
-    const { sharesField, quorumField } = this.props;
+    const { sharesField, quorumField, submittedOnce } = this.props;
     let statusMessage;
     const statusEnding = ' shares needed to recover secret.';
 
@@ -35,9 +36,10 @@ export default class SplitOptions extends Component {
     return (
       <div>
         <div className="split-options">
-          <NumberField field={quorumField}
+          <NumberField field={quorumField} submittedOnce={submittedOnce}
             label="Shares needed to recover the secret" />
-          <NumberField field={sharesField} label="Total number of shares" />
+          <NumberField field={sharesField} submittedOnce={submittedOnce}
+            label="Total number of shares" />
         </div>
         <div className="split-status-message">{statusMessage}</div>
       </div>

--- a/test/components/NumberField.spec.js
+++ b/test/components/NumberField.spec.js
@@ -11,7 +11,8 @@ describe('NumberField', () => {
         error: 'error',
         touched: true,
         invalid: true
-      }
+      },
+      submittedOnce: true
     };
     expect(shallow(<NumberField {...props} />).find('.error-label')).to.have.length(1);
   });

--- a/test/components/Split.spec.js
+++ b/test/components/Split.spec.js
@@ -35,9 +35,12 @@ describe('<Split />', () => {
     expect(split.find(WorkingIndicator)).to.have.length(1);
   });
 
-  it('should disable the button when invalid', () => {
+  it('should disable the button after an invalid submission', () => {
     props.invalid = true;
     const split = shallow(<Split {...props} />);
+    split.setState({
+      submittedOnce: true
+    });
     expect(split.find(Button).prop('disabled')).to.be.true();
   });
 });


### PR DESCRIPTION
## Status

Ready for review

## Description of Changes

Fixes #47 

Defers validation on the secret splitting screen until the first submission. If the submission is invalid, then the form starts doing continuous input validation.

## Testing

1. Try touching a field on the split screen before submission to verify continuous validation is off.
2. Try to submit an invalid submission.
3. Verify error messages on fields appear.
4. Try changing field inputs to verify continuous validation is turned on.