### PR TITLE
Use asar in packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "build": {
     "productName": "Sunder",
-    "asar": false,
     "linux": {
       "icon": "build/icons/",
       "target": [


### PR DESCRIPTION

## Status

Ready for review

## Description of Changes

Closes #92.

Enable asar. It is the default and recommended option.

## Testing

Build the app in /dist with `make build-deb` or `make build-dmg` and run it.