### PR TITLE
Use docker on Circle CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,46 @@
 version: 2.0
 jobs:
  build:
+   working_directory: /sunder
    docker:
-     - image: liliakai/sunder-build:latest
+     - image: docker:18.03.1-ce-git
    steps:
      - checkout
+     - setup_remote_docker
+     - restore_cache:
+         keys:
+           - v1-{{ .Branch }}
+         paths:
+           - /caches/sunder.tar
      - run:
-         name: npm install and build RustySecrets
+         name: Load Docker image layer cache
          command: |
-           # Hack to unbreak cargo fetching (we need HTTPS, not SSH URLs).
-           rm -f ~/.gitconfig
-           # Hack to force sourcing of rust env
-           source ~/.cargo/env
-           npm install
+           set +o pipefail
+           docker load -i /caches/sunder.tar | true
      - run:
-         name: Run unit tests and e2e tests
-         command: xvfb-run --server-args=$XVFB_ARGS make test
+         name: Build Docker image
+         command: |
+           docker build --cache-from=sunder-build -t sunder-build .
      - run:
-         name: Build docs
-         command: make docs-lint
+         name: Save Docker image layer cache
+         command: |
+           mkdir -p /caches
+           docker save -o /caches/sunder.tar sunder-build
+     - save_cache:
+         key: v1-{{ .Branch }}-{{ epoch }}
+         paths:
+           - /caches/sunder.tar
+     - run:
+         name: Create a volume to hold a copy of the repo and build output
+         command: |
+           # create a dummy container which will hold a volume with the repo
+           docker create -v /sunder --name sunder-repo alpine:3.4 /bin/true
+           # ensure this volume belongs to the 'node' user id in sunder-build
+           chown -R 1000 /sunder
+           # copy the repo into this volume
+           docker cp /sunder sunder-repo:/
+     - run:
+         name: Run the tests in the docker container
+         command: |
+           # start an application container using this volume
+           docker run --volumes-from sunder-repo sunder-build:latest tools/docker-test.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,21 @@
 version: 2.0
 jobs:
  build:
-   machine:
-     image: circleci/classic:latest
+   docker:
+     - image: liliakai/sunder-build:latest
    steps:
      - checkout
      - run:
-         name: Install rust
-         command: |
-           curl https://sh.rustup.rs -sSf | sh -s -- -y
-           # Hack to unbreak cargo fetching (we need HTTPS, not SSH URLs).
-           rm -f ~/.gitconfig
-     - run:
-         name: Install python requirements for docs.
-         command: pip install -r requirements.txt
-     - run:
          name: npm install and build RustySecrets
          command: |
+           # Hack to unbreak cargo fetching (we need HTTPS, not SSH URLs).
+           rm -f ~/.gitconfig
            # Hack to force sourcing of rust env
            source ~/.cargo/env
            npm install
      - run:
          name: Run unit tests and e2e tests
-         command: make test
+         command: xvfb-run --server-args=$XVFB_ARGS make test
      - run:
          name: Build docs
          command: make docs-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
          paths:
            - /caches/sunder.tar
      - run:
-         name: Create a volume to hold a copy of the repo and build output
+         name: Create a volume with a copy of the repository
          command: |
            # create a dummy container which will hold a volume with the repo
            docker create -v /sunder --name sunder-repo alpine:3.4 /bin/true
@@ -40,7 +40,15 @@ jobs:
            # copy the repo into this volume
            docker cp /sunder sunder-repo:/
      - run:
-         name: Run the tests in the docker container
+         name: Build and package
+         command: |
+           docker run --volumes-from sunder-repo sunder-build:latest tools/build-sunder-debian-packages.sh
+     - run:
+         name: Test
          command: |
            # start an application container using this volume
            docker run --volumes-from sunder-repo sunder-build:latest tools/docker-test.sh
+     - run:
+         name: Lint docs
+         command: |
+           docker run --volumes-from sunder-repo sunder-build:latest make docs-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
            - v1-{{ .Branch }}
          paths:
            - /caches/sunder.tar
+           - /sunder/node_modules
      - run:
          name: Load Docker image layer cache
          command: |
@@ -26,10 +27,6 @@ jobs:
          command: |
            mkdir -p /caches
            docker save -o /caches/sunder.tar sunder-build
-     - save_cache:
-         key: v1-{{ .Branch }}-{{ epoch }}
-         paths:
-           - /caches/sunder.tar
      - run:
          name: Create a volume with a copy of the repository
          command: |
@@ -52,3 +49,12 @@ jobs:
          name: Lint docs
          command: |
            docker run --volumes-from sunder-repo sunder-build:latest make docs-lint
+     - run:
+         name: Cache node modules
+         command: |
+           docker cp sunder-repo:/sunder/node_modules /sunder/
+     - save_cache:
+         key: v1-{{ .Branch }}-{{ epoch }}
+         paths:
+           - /caches/sunder.tar
+           - /sunder/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=8.9.4
+ARG NODE_VERSION=8.15.1
 FROM node:$NODE_VERSION
 # Using these to provide advanced pruning later
 LABEL org="Freedom of the Press"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,27 @@ RUN apt-get install -y --no-install-recommends  \
     xz-utils && \
     rm -rf /var/cache/apt/archives/*
 
+# Required for starting electron
+RUN apt-get install -y --no-install-recommends  \
+    libgtk-3-0 \
+    libx11-xcb1 \
+    libXtst6 \
+    libxss1 \
+    libasound2 \
+    xvfb xauth \
+    && rm -rf /var/cache/apt/archives/*
+
+# Install python for building docs with sphinx
+RUN apt-get update && \
+    apt-get install -y python python-dev python-pip python-virtualenv && \
+    rm -rf /var/cache/apt/archives/*
+
+# Install sphinx and related python requirements
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+
 RUN if test $UID != 1000 ; then usermod -u $UID node; fi && echo "node ALL=(ALL) NOPASSWD:/bin/sunder-perm-fix" >> /etc/sudoers
 
 # For compatibility with grsecurity-patched kernels and perm clean-up

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get install -y --no-install-recommends  \
 RUN apt-get install -y --no-install-recommends  \
     libgtk-3-0 \
     libx11-xcb1 \
-    libXtst6 \
+    libxtst6 \
     libxss1 \
     libasound2 \
     xvfb xauth \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,14 @@ build-deb: docker-build ## Builds Sunder Debian packages for Linux
 		-v fpf-sunder-node:/sunder/node_modules \
 		sunder-build:latest
 
+.PHONY: docker-test
+docker-test: docker-build ## Runs tests in the Docker image
+	docker volume create fpf-sunder-node && \
+	docker run \
+		-v $(PWD):/sunder \
+		-v fpf-sunder-node:/sunder/node_modules \
+		sunder-build:latest tools/docker-test.sh
+
 .PHONY: npm-install-init
 npm-install-init: ## Installs npm modules locally only if node_modules/ absent
 	if [ ! -d node_modules ] ; then \

--- a/tools/build-sunder-debian-packages.sh
+++ b/tools/build-sunder-debian-packages.sh
@@ -36,8 +36,18 @@ function build() {
     fi
 }
 
+function verify() {
+    count=`ls -1 dist/sunder*.deb 2>/dev/null | wc -l`
+    if [ $count == 0 ]
+    then
+        printf "BUILD FAILED! .deb not found.\\n"
+        exit 1
+    fi
+}
+
 
 img_extract
 perm_fix
 npm_install
 build
+verify

--- a/tools/docker-test.sh
+++ b/tools/docker-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# docker-test
+# This script is intended to be run in the docker container produced by our Dockerfile
+
+# Set up Rust PATH
+source /home/node/.cargo/env
+
+xvfb-run --server-args=$XVFB_ARGS make test

--- a/tools/docker-test.sh
+++ b/tools/docker-test.sh
@@ -5,4 +5,7 @@
 # Set up Rust PATH
 source /home/node/.cargo/env
 
+sudo /bin/sunder-perm-fix
+npm install
+
 xvfb-run --server-args=$XVFB_ARGS make test

--- a/tools/sunder-perm-fix.sh
+++ b/tools/sunder-perm-fix.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-chown -R node /sunder/node_modules
+if [[ -d "/sunder/node_modules" ]]; then
+    chown -R node /sunder/node_modules
+fi


### PR DESCRIPTION
**Background**

In the interest of future-proofing our CI setup, it is best to reconfigure our CircleCI config to run in a docker container instead of the dedicated ephemeral VM we have been using up to now, because Circle have warned[1] they might start charging for use of the latter.

**Changes**
Since we already maintain a Dockerfile for building the linux distribution, I simply extended it with a few dependencies to enable to run tests and build docs. Developers can now `make docker-test` to run tests in a locally-built docker container.

I then followed Circle's guide[2] to get CI to build its own docker container from that Dockerfile (complete with layer caching), and run the tests inside it. This also wins us some maintainability points on the Dockerfile itself, which is now effectively validated on every CI run.

Finally, I added a step to the CI flow to do a complete build of the linux distributable and check that a .deb is produced, which effectively validates the build script and prevents accidental build breakages like this one: https://github.com/freedomofpress/sunder/pull/144#pullrequestreview-160282291

[1] https://circleci.com/docs/2.0/executor-types/
[2] https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/

**Summary**

CI now does the following, and blocks merge if any of the steps fail:

1. Build a docker container from the Dockerfile
2. Cache docker layers
2. Run tests
3. Lint docs
4. Build a .deb
5. Cache node modules