### PR TITLE
Replace document.write to silence a console warning

### DIFF
--- a/app.html
+++ b/app.html
@@ -26,7 +26,7 @@
       (function() {
         const script = document.createElement('script');
         script.src = (process.env.HOT) ? 'http://localhost:3000/dist/bundle.js' : 'dist/bundle.js';
-        document.write(script.outerHTML);
+        document.body.appendChild(script);
       }());
     </script>
   </body>


### PR DESCRIPTION
## Status

Ready for review 

## Description of Changes

Fixes #78

Removes the warning about "A Parser-blocking, cross site... " when hot-reloading in a development environment.

Changes proposed in this pull request:

## Testing

`npm run dev` and verify the warning is not printed in devtools