### PR TITLE
Move comment in Dockerfile to silence a warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,10 @@ ENV UID ${UID:-1000}
 RUN apt-get update && apt-get upgrade -y # 2018-02-08 && \
     rm -rf /var/cache/apt/archives/*
 
+# Required for electron-builder:
+# https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build#linux
 RUN apt-get install -y --no-install-recommends  \
     graphicsmagick \
-    # Required for electron-builder:
-    # https://github.com/electron-userland/electron-builder/wiki/Multi-Platform-Build#linux
     icnsutils \
     libgconf2-dev \
     libgtk2.0-dev \


### PR DESCRIPTION
Removes the following warning printed when building the container:

[WARNING]: Empty continuation line found in:
    RUN apt-get install -y --no-install-recommends      graphicsmagick
    icnsutils     libgconf2-dev     libgtk2.0-dev     libnss3-dev
    sudo     xz-utils &&     rm -rf /var/cache/apt/archives/*
    [WARNING]: Empty continuation lines will become errors in a future
    release.

## Status

Ready for review