### PR TITLE
Adds no-maintenance notice to project README & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Sunder
 
-[![CircleCI](https://circleci.com/gh/freedomofpress/sunder.svg?style=svg&circle-token=b2396d4ad46cc09a0b6f515855e56032fe6ce4bf)](https://circleci.com/gh/freedomofpress/sunder) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/freedomofpress/sunder?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+**Important:** As of June 2019, Freedom of the Press Foundation has discontinued its work on the Sunder project.
+For actively maintained implementations of Shamir's Secret Sharing, consider using [Mozilla SOPS](https://github.com/mozilla/sops/)
+or [Hashicorp Vault](https://github.com/hashicorp/vault).
+
+----------
 
 ![Sunder user interface](https://sunder.readthedocs.io/en/latest/_images/create_secret_shards_filled.png)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,11 @@
 Welcome to Sunder
 =================
 
+.. warning:: As of June 2019, Sunder is no longer undergoing active development,
+   and will not receive security fixes. The repository has been archived.
+   For actively maintained implementations of Shamir's Secret Sharing,
+   consider using `Mozilla SOPS`_ or `Hashicorp Vault`_.
+
 Sunder is a user-friendly graphical interface for cryptographic secret sharing.
 
 If you're new to cryptographic secret sharing,
@@ -9,12 +14,6 @@ we recommend reading
 :doc:`about_sunder`,
 and :doc:`threat_modeling`
 before trying to use Sunder.
-
-.. warning:: This is an alpha release.
-   There may be bugs,
-   it has not received a security audit,
-   and we do not guarantee forwards or backwards compatibilty.
-   **Use at your own risk.**
 
 Once you understand the concepts behind Sunder,
 you might be interested in learning how to :doc:`install`.
@@ -28,6 +27,8 @@ check out :ref:`why-use-secret-sharing` and :ref:`real-world-examples`.
 The code is open source, and `available on GitHub`_.
 
 .. _available on GitHub: https://github.com/freedomofpress/sunder
+.. _Mozilla SOPS: https://github.com/mozilla/sops
+.. _Hashicorp Vault: https://github.com/hashicorp/vault
 
 .. toctree::
    :caption: Topic Guides


### PR DESCRIPTION
## Status

Ready for review.

## Description of Changes

FPF is no longer maintaining Sunder, so a prominent warning explaining
the lack of maintenance should be displayed at the top of the README.
After merge, we'll formally mark the repo as "archived," effectively
making it read-only.

## Testing

1. Run `make docs` and view the new docs changes on the homepage, and confirm the information is clear.
2. Review the README changes (try `pip install grip && grip README.md` for local display) and confirm the information added is clear. 
